### PR TITLE
Update SSH deployment arguments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         uses: easingthemes/ssh-deploy@v4.0.5
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
-          ARGS: "-avzr --delete"
+          ARGS: "-rlgoDzvc -i"
           SOURCE: "dist/"
           REMOTE_HOST: ${{ vars.REMOTE_HOST }}
           REMOTE_USER: ${{ vars.REMOTE_USER }}


### PR DESCRIPTION
This pull request updates the SSH deployment arguments in the GitHub Actions workflow file. The ARGS variable has been changed from "-avzr --delete" to "-rlgoDzvc -i". This change ensures that the deployment process uses the correct arguments for syncing files with the remote server.