### PR TITLE
Add API routes for fetching fiche by ID and fetching all fiches

### DIFF
--- a/src/pages/api/[lang]/getFicheById/[id].ts
+++ b/src/pages/api/[lang]/getFicheById/[id].ts
@@ -1,0 +1,49 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+import type { EntryType } from "perf_hooks";
+import { getRefConfig } from "referentiel-config";
+
+export async function GET({ params, request }) {
+  const id = params.id;
+  const lang = params.lang;
+  const entries: CollectionEntry<"fiches">[] = await getCollection("fiches");
+  const filteredEntries: CollectionEntry<"fiches">[] = entries
+    .filter((entry) => entry.data.language === lang)
+    .filter((entry) => entry.data.published)
+    .filter((entry) => entry.data.refID === params.id);
+  if (entries && filteredEntries.length > 1) {
+    throw new Error("Duplicate ID on `Fiches`.");
+  }
+  const entry = filteredEntries[0];
+  const [_lang, ...slug] = entry.slug.split("/");
+  let o = {
+    id: entry.data.refID,
+    lang: lang,
+    title: entry.data.title,
+    lifecycle: entry.data.lifecycle,
+    slug: `/${import.meta.env.PUBLIC_BASE !== "" ? import.meta.env.PUBLIC_BASE + "/" : ""}fr/${entry.collection}/${slug}`,
+  };
+  if (getRefConfig().featuresEnabled.scope) {
+    o["scope"] = entry.data.scope;
+  }
+  return new Response(JSON.stringify(o));
+}
+
+export async function getStaticPaths() {
+  const entries = await getCollection("fiches");
+  const paths = entries
+    .filter((entry) =>
+      import.meta.env.MODE === "development" ? "true" : entry.data.published,
+    )
+    .map((entry) => {
+      const [lang, ...slug] = entry.slug.split("/");
+      return {
+        params: {
+          lang,
+          id: entry.data.refID,
+        },
+        props: { entry, entries },
+      };
+    });
+
+  return paths;
+}

--- a/src/pages/api/[lang]/getFiches.ts
+++ b/src/pages/api/[lang]/getFiches.ts
@@ -1,0 +1,40 @@
+import { code_languages } from "@i18n/ui";
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { getRefConfig } from "referentiel-config";
+
+export const GET: APIRoute = async ({ params, request }) => {
+  const lang = params.lang;
+  const entries = await getCollection("fiches");
+  const output: any = {
+    ref: import.meta.env.PUBLIC_REF_NAME,
+    version: getRefConfig().refInformations.currentVersion,
+    refs: [],
+  };
+  entries
+    .filter((entry) =>
+      import.meta.env.MODE === "development" ? "true" : entry.data.published,
+    )
+    .filter((entry) => entry.data.language === "fr")
+    .map((entry) => {
+      const [_lang, ...slug] = entry.slug.split("/");
+      let o = {
+        id: entry.data.refID,
+        lang: lang,
+        title: entry.data.title,
+        lifecycle: entry.data.lifecycle,
+        slug: `/${import.meta.env.PUBLIC_BASE !== "" ? import.meta.env.PUBLIC_BASE + "/" : ""}fr/${entry.collection}/${slug}`,
+      };
+      if (getRefConfig().featuresEnabled.scope) {
+        o["scope"] = entry.data.scope;
+      }
+      output.refs.push(o);
+    });
+  return new Response(JSON.stringify(output));
+};
+
+export async function getStaticPaths() {
+  return code_languages.map((lang) => {
+    return { params: { lang } };
+  });
+}


### PR DESCRIPTION
This pull request adds API routes for fetching a fiche by ID and fetching all fiches. The routes are implemented using the Astro framework and utilize the `getCollection` and `getRefConfig` functions. The routes return JSON responses with the necessary data for each fiche.