### PR TITLE
Update Content-Type and Charset in API response headers

### DIFF
--- a/src/pages/api/[lang]/getFicheById/[id].ts
+++ b/src/pages/api/[lang]/getFicheById/[id].ts
@@ -28,7 +28,8 @@ export async function GET({ params, request }) {
   return new Response(JSON.stringify(o), {
     status: 200,
     headers: {
-      "Content-Type": "application/json;charset=utf-8",
+      "Content-Type": "application/json; charset=UTF-8",
+      Charset: "UTF-8",
     },
   });
 }
@@ -46,7 +47,6 @@ export async function getStaticPaths() {
           lang,
           id: entry.data.refID,
         },
-        props: { entry, entries },
       };
     });
 

--- a/src/pages/api/[lang]/getFiches.ts
+++ b/src/pages/api/[lang]/getFiches.ts
@@ -1,5 +1,5 @@
-import { code_languages } from "@i18n/ui";
 import type { APIRoute } from "astro";
+import { code_languages } from "@i18n/ui";
 import { getCollection } from "astro:content";
 import { getRefConfig } from "referentiel-config";
 
@@ -33,7 +33,8 @@ export const GET: APIRoute = async ({ params, request }) => {
   return new Response(JSON.stringify(output), {
     status: 200,
     headers: {
-      "Content-Type": "application/json;charset=utf-8",
+      "Content-Type": "application/json; charset=UTF-8",
+      Charset: "UTF-8",
     },
   });
 };


### PR DESCRIPTION
This pull request updates the Content-Type and Charset in the API response headers to "application/json; charset=UTF-8". This ensures consistent encoding and improves compatibility with different clients.